### PR TITLE
Fix: Apply restart annotation to pod template metadata instead of top-level metadata

### DIFF
--- a/pkg/resources/manager_test.go
+++ b/pkg/resources/manager_test.go
@@ -60,11 +60,11 @@ func TestRestartDeployment(t *testing.T) {
 	err := manager.RestartDeployment(ctx, namespacedName)
 	assert.NoError(t, err)
 
-	// Verify the restart annotation was added
+	// Verify the restart annotation was added to the pod template
 	updatedDeployment := &appsv1.Deployment{}
 	err = client.Get(ctx, namespacedName, updatedDeployment)
 	assert.NoError(t, err)
-	assert.Contains(t, updatedDeployment.Annotations, "kubectl.kubernetes.io/restartedAt")
+	assert.Contains(t, updatedDeployment.Spec.Template.Annotations, "kubectl.kubernetes.io/restartedAt")
 }
 
 func TestRestartStatefulSet(t *testing.T) {
@@ -114,11 +114,11 @@ func TestRestartStatefulSet(t *testing.T) {
 	err := manager.RestartStatefulSet(ctx, namespacedName)
 	assert.NoError(t, err)
 
-	// Verify the restart annotation was added
+	// Verify the restart annotation was added to the pod template
 	updatedStatefulSet := &appsv1.StatefulSet{}
 	err = client.Get(ctx, namespacedName, updatedStatefulSet)
 	assert.NoError(t, err)
-	assert.Contains(t, updatedStatefulSet.Annotations, "kubectl.kubernetes.io/restartedAt")
+	assert.Contains(t, updatedStatefulSet.Spec.Template.Annotations, "kubectl.kubernetes.io/restartedAt")
 }
 
 func TestRestartDaemonSet(t *testing.T) {
@@ -167,9 +167,9 @@ func TestRestartDaemonSet(t *testing.T) {
 	err := manager.RestartDaemonSet(ctx, namespacedName)
 	assert.NoError(t, err)
 
-	// Verify the restart annotation was added
+	// Verify the restart annotation was added to the pod template
 	updatedDaemonSet := &appsv1.DaemonSet{}
 	err = client.Get(ctx, namespacedName, updatedDaemonSet)
 	assert.NoError(t, err)
-	assert.Contains(t, updatedDaemonSet.Annotations, "kubectl.kubernetes.io/restartedAt")
+	assert.Contains(t, updatedDaemonSet.Spec.Template.Annotations, "kubectl.kubernetes.io/restartedAt")
 }


### PR DESCRIPTION
# Description
## Issue
KubeTide was incorrectly applying the `kubectl.kubernetes.io/restartedAt` annotation to the top-level metadata of workload resources (Deployments, StatefulSets, DaemonSets) instead of to the Pod template metadata. This caused KubeTide to appear to be working (logs showed success, annotations were being updated) while pods weren't actually being restarted.

## Root Cause
In the `patchRestartAnnotation` function in `pkg/resources/manager.go`, we were using the generic `obj.GetAnnotations()` and `obj.SetAnnotations()` methods which only affect the top-level resource metadata. For workload resources, Kubernetes looks for changes to the Pod template metadata to trigger a restart.

## Changes
1. Modified `patchRestartAnnotation` to handle workload resources differently:
   - For Deployments, StatefulSets, and DaemonSets, apply the restart annotation to `.spec.template.metadata.annotations`
2. Updated tests to verify annotations are added to the correct location
