### PR TITLE
Optimize CI: Move gosec security scanning from Dockerfile to GitHub Actions

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -61,7 +61,7 @@ jobs:
         run: go build -v ./...
         
       - name: Security scan
-        uses: securego/gosec@v2
+        uses: securego/gosec@master
         with:
           args: ./...
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -61,7 +61,7 @@ jobs:
         run: go build -v ./...
         
       - name: Security scan
-        uses: securego/gosec@master
+        uses: securego/gosec@v2
         with:
           args: ./...
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.24'
 
       - name: Security scan
-        uses: securego/gosec@v2
+        uses: securego/gosec@master
         with:
           args: ./...
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,11 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Security scan
+        uses: securego/gosec@v2
+        with:
+          args: ./...
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM golang:1.24-alpine AS builder
 
 WORKDIR /workspace
 
-# Install security scanner
-RUN go install github.com/securego/gosec/v2/cmd/gosec@latest
-
 # Copy Go module files and download dependencies
 COPY go.mod go.sum* ./
 RUN go mod download
@@ -18,9 +15,6 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags="-w -s" \
     -o kubetide cmd/kubetide/main.go
-
-# Run security scan
-RUN gosec -quiet ./...
 
 # Final stage
 FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
### Changes
This PR optimizes the release CI pipeline by moving the security scanning with gosec from the Dockerfile to the GitHub Actions workflow. 

- **Added**: Security scan step in the GitHub release workflow that uses the gosec GitHub Action
- **Removed**: gosec installation and scanning steps from the Dockerfile

### Benefits
- **Faster builds**: The gosec GitHub Action is optimized and cached, eliminating the need to download and install gosec each time
- **More consistent scanning**: Security issues are detected earlier in the pipeline
